### PR TITLE
Inject dependencies in Connector

### DIFF
--- a/src/Server/Connector.php
+++ b/src/Server/Connector.php
@@ -16,11 +16,13 @@ use Psr\Http\Message\ResponseInterface;
 
 class Connector
 {
-    protected Client $client;
+    public function __construct(
+        protected Client $client,
+    ) {}
 
-    public function __construct(string $mockServerUrl)
+    public static function fromUrl(string $mockServerUrl): self
     {
-        $this->client = $this->buildClient($mockServerUrl);
+        return new self(new Client(['base_uri' => $mockServerUrl]));
     }
 
     /**
@@ -108,11 +110,6 @@ class Connector
                 $exception
             );
         }
-    }
-
-    protected function buildClient(string $mockServerUrl): Client
-    {
-        return new Client(['base_uri' => $mockServerUrl]);
     }
 
     protected function getMessageFromResponse(ResponseInterface $response): string

--- a/src/Server/MockServer.php
+++ b/src/Server/MockServer.php
@@ -84,7 +84,7 @@ class MockServer
         if (static::$connector) {
             return static::$connector;
         }
-        static::$connector = new Connector(static::$mockServerUrl);
+        static::$connector = Connector::fromUrl(static::$mockServerUrl);
 
         return static::$connector;
     }


### PR DESCRIPTION
By using [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection) for the `Client` in the `Connector`, testing the connector can be simplified. (removed  nearly 100 lines of code)

No need for anonymous classes, simply inject the mock client into the `Connector`.

Constructing by url has been moved to a static constructor `fromUrl(string $url)` which is now used by the `MockServer`